### PR TITLE
Immediately get the value of an option if he contains simple values

### DIFF
--- a/src/main/scala/com/gilt/util/Matchers.scala
+++ b/src/main/scala/com/gilt/util/Matchers.scala
@@ -1,0 +1,23 @@
+package com.gilt.util
+
+
+/**
+ * Extractor object to be used in match statements. If used against
+ * an Option it will match if the type of the Option's value is of type:
+ *
+ * - Int
+ * - Long
+ * - Float
+ * - BigDecimal
+ * - Double
+ * - String
+ */
+object PrimitiveOption {
+  def unapply(opt: Option[Any]): Option[Any] = opt match {
+    case Some(o) => if (isPrimitiveType(o)) Some(o) else None
+    case _ => None
+  }
+
+  def isPrimitiveType(obj: Any) = obj.isInstanceOf[Int] || obj.isInstanceOf[Long] || obj.isInstanceOf[Float] ||
+                                  obj.isInstanceOf[BigDecimal] || obj.isInstanceOf[Double] || obj.isInstanceOf[String]
+}

--- a/src/test/scala/com/gilt/handlebars/HandlebarsVisitorSpec.scala
+++ b/src/test/scala/com/gilt/handlebars/HandlebarsVisitorSpec.scala
@@ -110,6 +110,14 @@ class HandlebarsVisitorSpec extends Specification {
       visitor.visit(program) must beEqualTo("HELLO, world.")
     }
 
+    "visit a program and render a section, where the block context is an Option (Primitive)" in {
+      val program = Handlebars.parse("{{greeting}}, world.")
+      val visitor = HandlebarsVisitor(new {
+        val greeting = Some("Hello")
+      })
+      visitor.visit(program) must beEqualTo("Hello, world.")
+    }
+
     "visit a program and render a section, where the block context is an Iterable" in {
       val program = Handlebars.parse("{{#names}}{{toString}} & {{/names}}me")
       val visitor = HandlebarsVisitor(new {


### PR DESCRIPTION
To ease the use of options in scandlebars.

If you have a property who's value is "Some(Hi)" you can now immediately get the value "Hi" without opening a block. For example:

```
val context = new { val greeting = Some("Hello") }
```

When context is passed into a scandelbars template you can get two results

```
{{! Hello }}
{{greeting}}
```

or (as it worked before) if you want to dive into the Option

```
{{! HELLO }}
{{#greeting}}{{toUpperCase}}{{/greeting}}
```
