### PR TITLE
 Better Option support

### DIFF
--- a/src/test/scala/com/gilt/handlebars/HandlebarsVisitorSpec.scala
+++ b/src/test/scala/com/gilt/handlebars/HandlebarsVisitorSpec.scala
@@ -110,6 +110,22 @@ class HandlebarsVisitorSpec extends Specification {
       visitor.visit(program) must beEqualTo("HELLO, world.")
     }
 
+    "visit a program and render a section, where the block context is a Some (Primitive)" in {
+      val program = Handlebars.parse("{{greeting}}, world.")
+      val visitor = HandlebarsVisitor(new {
+        val greeting = Some("Hello")
+      })
+      visitor.visit(program) must beEqualTo("Hello, world.")
+    }
+
+    "visit a program and render a section, where the block context is None (Primitive)" in {
+      val program = Handlebars.parse("{{greeting}}, world.")
+      val visitor = HandlebarsVisitor(new {
+        val greeting = None
+      })
+      visitor.visit(program) must beEqualTo(", world.")
+    }
+
     "visit a program and render a section, where the block context is an Iterable" in {
       val program = Handlebars.parse("{{#names}}{{toString}} & {{/names}}me")
       val visitor = HandlebarsVisitor(new {


### PR DESCRIPTION
To ease the use of options in scandlebars.

If you have a property who's value is "Some(Hi)" you can now immediately get the value "Hi" without opening a block. For example:

```
val context = new { val greeting = Some("Hello") }
```

When context is passed into a scandelbars template you can get two results

```
{{! Hello }}
{{greeting}}
```

or if you want to dive into the Option

```
{{! HELLO }}
{{#greeting}}{{toUpperCase}}{{/greeting}}
```
