### PR TITLE
Only convert args from list to array if they actually exist

### DIFF
--- a/src/main/scala/com/gilt/handlebars/HandlebarsVisitor.scala
+++ b/src/main/scala/com/gilt/handlebars/HandlebarsVisitor.scala
@@ -305,8 +305,12 @@ trait Context[+T] {
       if (method.getReturnType eq classOf[com.google.common.base.Optional[_]]) {
         GuavaOptionalHelper.invoke(context, method, args)
       } else {
-        val result = method.invoke(context, args.map(_.asInstanceOf[AnyRef]): _*)
-
+        val result = {
+          if (args.isEmpty)
+            method.invoke(context)
+          else
+            method.invoke(context, args.map(_.asInstanceOf[AnyRef]): _*)
+        }
         result match {
           case Some(o) => if (isPrimitiveType(o)) Some(o) else Some(result)
           case None => Some("")


### PR DESCRIPTION
Profiling tool suggested this was using disproportionate amounts of CPU
as it was using reflection to create the new Array

Tests afterwards indicate a performance improvement but not a
dramatic one - maybe 10%
