### PR TITLE
Add support for unescaped helper mustaches

### DIFF
--- a/src/main/scala/com/gilt/handlebars/HandlebarsGrammar.scala
+++ b/src/main/scala/com/gilt/handlebars/HandlebarsGrammar.scala
@@ -56,7 +56,9 @@ class HandlebarsGrammar(delimiters: (String, String)) extends JavaTokenParsers {
 
   def unescapedMustache =
       mustachify("{" ~> pad(path) <~ "}" ^^ {Mustache(_, escaped=false)}) |
-      mustachify("&" ~> pad(path) ^^ {Mustache(_, escaped=false)})
+      mustachify("{" ~> pad(helper) <~ "}" ^^ { case id ~ list => Mustache(id, list, escaped=false) }) |
+      mustachify("&" ~> pad(path) ^^ {Mustache(_, escaped=false)}) |
+      mustachify("&" ~> pad(helper) ^^ { case id ~ list => Mustache(id, list, escaped=false) })
 
   def mustache = not(elseStache) ~> mustachify(pad(mustachable))
 

--- a/src/test/scala/com/gilt/handlebars/HandlebarsVisitorSpec.scala
+++ b/src/test/scala/com/gilt/handlebars/HandlebarsVisitorSpec.scala
@@ -238,12 +238,32 @@ class HandlebarsVisitorSpec extends Specification {
       visitor.visit(program) must beEqualTo("<strong>Hello</strong>, world.")
     }
 
+    "allow unescaped helper mustaches: {{{helper arg1 arg2}}}" in {
+      val program = Handlebars.parse("{{{greeting title addressee}}}.")
+      val visitor = HandlebarsVisitor(new {
+        def greeting(title: String, who: String) = "<strong>Hello</strong>, "+title+" "+who
+        val title = "Mr."
+        val addressee = "Mark"
+      })
+      visitor.visit(program) must beEqualTo("<strong>Hello</strong>, Mr. Mark.")
+    }
+
     "allow unescaped mustaches with the ampersand syntax" in {
       val program = Handlebars.parse("{{& greeting}}, world.")
       val visitor = HandlebarsVisitor(new {
         val greeting = "<strong>Hello</strong>"
       })
       visitor.visit(program) must beEqualTo("<strong>Hello</strong>, world.")
+    }
+
+    "allow unescaped helper mustaches with the ampersand syntax: {{& helper arg1 arg2}}" in {
+      val program = Handlebars.parse("{{& greeting title addressee}}.")
+      val visitor = HandlebarsVisitor(new {
+        def greeting(title: String, who: String) = "<strong>Hello</strong>, "+title+" "+who
+        val title = "Mr."
+        val addressee = "Mark"
+      })
+      visitor.visit(program) must beEqualTo("<strong>Hello</strong>, Mr. Mark.")
     }
 
     "visit a program and render an inverted section: {{^absent}}Nothing{{/absent}}" in {
@@ -282,8 +302,6 @@ class HandlebarsVisitorSpec extends Specification {
       val visitor = HandlebarsVisitor(new { val defined = new {}})
       visitor.visit(program) must beEqualTo("")
     }
-
-
 
     "visit a program and resolve a helper mustache: {{helper argument}}" in {
       val program = Handlebars.parse("{{greeting addressee}}.")


### PR DESCRIPTION
Noticed that when trying to use unescaped helper mustaches, it resulted in an error.

I'm actually not very familiar with the syntax used in the grammar file, but I gave it a shot and it seems to work, at least for my purposes.
