### PR TITLE
remove to String when getting helper parameters

### DIFF
--- a/src/main/scala/com/gilt/handlebars/helper/HelperOptionsBuilder.scala
+++ b/src/main/scala/com/gilt/handlebars/helper/HelperOptionsBuilder.scala
@@ -80,7 +80,7 @@ class HelperOptionsBuilder(context: Context[Any],
         warn("Path not found for helper: %s".format(i.string))
         ""
       }
-    case a => a.toString
+    case a => a
   }
 
   private val inverseNode: Option[Node] = program match {


### PR DESCRIPTION
instead of getting this "StringParameter(test)" as parameter in helper argument, it will give this StringParameter("test") which can be pattern matched.