### PR TITLE
update versions and readme to match latest release artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ This project began as an attempt to learn Scala and to experiment with Scala's [
 
 If you're using SBT you can add this line to your build.sbt file.
 
-    libraryDependencies += "com.gilt" %% "handlebars-scala" % "2.0.1"
-    
+    libraryDependencies += "com.gilt" %% "handlebars-scala" % "2.1.1"
+
 ## Usage
 
 Given a template:
@@ -171,7 +171,7 @@ If you wish for more type-safety, Handlebars-scala comes with integration for pl
 
 To use:
 
-    libraryDependencies += "com.gilt" %% "handlebars-scala-play-json" % "2.0.1"
+    libraryDependencies += "com.gilt" %% "handlebars-scala-play-json" % "2.1.1"
 
 [Example / usage](addons/play-json/README.md)
 

--- a/addons/play-json/README.md
+++ b/addons/play-json/README.md
@@ -6,7 +6,7 @@ Play-JSON data bindings for `handlebars.scala`. Requires `play-json` `2.4.x`.
 # Installation:
 
 ```scala
-libraryDependencies += "com.gilt" %% "handlebars-scala-play-json" % "2.0.1"
+libraryDependencies += "com.gilt" %% "handlebars-scala-play-json" % "2.1.1"
 ```
 
 # Example:

--- a/version.sbt
+++ b/version.sbt
@@ -1,2 +1,1 @@
-
-version in ThisBuild := "2.0.1"
+version in ThisBuild := "2.1.1"


### PR DESCRIPTION
readme still references version 2.0.1 when 2.1.1 has apparently been published, and handlebars-scala-play-json only exists at that version.