### PR TITLE
Add support for nested expressions

### DIFF
--- a/src/main/scala/com/gilt/handlebars/scala/parser/Node.scala
+++ b/src/main/scala/com/gilt/handlebars/scala/parser/Node.scala
@@ -18,7 +18,7 @@ trait IdentifierNode extends ValueNode {
 case class Program(statements: Seq[Node], inverse: Option[Program] = None) extends Node
 
 case class Mustache(path: IdentifierNode,
-    params: Seq[ValueNode] = Nil,
+    params: Seq[Either[Mustache, ValueNode]] = Nil,
     hash: HashNode = HashNode(Map.empty),
     unescaped: Boolean = false) extends Node {
   val eligibleHelper: Boolean = path.isSimple

--- a/src/test/scala/com/gilt/handlebars/scala/parser/HandlebarsGrammarSpec.scala
+++ b/src/test/scala/com/gilt/handlebars/scala/parser/HandlebarsGrammarSpec.scala
@@ -93,7 +93,7 @@ class HandlebarsGrammarSpec extends FunSpec with Matchers with ParserMatchers {
       parsers("{{foo bar}}") should succeedWithResult {
         Program(List(
           Mustache(
-            Identifier(List("foo")), List(Identifier(List("bar")))
+            Identifier(List("foo")), List(Right(Identifier(List("bar"))))
           )
         ))
       }
@@ -104,7 +104,7 @@ class HandlebarsGrammarSpec extends FunSpec with Matchers with ParserMatchers {
         Program(List(
           Mustache(
             Identifier(List("foo")), List(
-              Identifier(List("bar")), StringParameter("baz")
+              Right(Identifier(List("bar"))), Right(StringParameter("baz"))
             )
           )
         ))
@@ -116,7 +116,7 @@ class HandlebarsGrammarSpec extends FunSpec with Matchers with ParserMatchers {
         Program(List(
           Mustache(
             Identifier(List("foo")), List(
-              IntegerParameter(1)
+              Right(IntegerParameter(1))
             )
           )
         ))
@@ -128,7 +128,7 @@ class HandlebarsGrammarSpec extends FunSpec with Matchers with ParserMatchers {
         Program(List(
           Mustache(
             Identifier(List("foo")), List(
-              BooleanParameter(true)
+              Right(BooleanParameter(true))
             )
           )
         ))
@@ -138,7 +138,7 @@ class HandlebarsGrammarSpec extends FunSpec with Matchers with ParserMatchers {
         Program(List(
           Mustache(
             Identifier(List("foo")), List(
-              BooleanParameter(false)
+              Right(BooleanParameter(false))
             )
           )
         ))
@@ -150,7 +150,24 @@ class HandlebarsGrammarSpec extends FunSpec with Matchers with ParserMatchers {
         Program(List(
           Mustache(
             Identifier(List("foo")), List(
-              DataNode(Identifier(List("bar")))
+              Right(DataNode(Identifier(List("bar"))))
+            )
+          )
+        ))
+      }
+    }
+
+
+    it("parses nested mustaches") {
+      parsers("{{foo (nestedFoo true)}}") should succeedWithResult {
+        Program(List(
+          Mustache(
+            Identifier(List("foo")), List(
+              Left(Mustache(
+                Identifier(List("nestedFoo")), List(
+                  Right(BooleanParameter(true))
+                )
+              ))
             )
           )
         ))

--- a/src/test/scala/com/gilt/handlebars/scala/visitor/BuiltInHelperSpec.scala
+++ b/src/test/scala/com/gilt/handlebars/scala/visitor/BuiltInHelperSpec.scala
@@ -395,6 +395,42 @@ class BuiltInHelperSpec extends FunSpec with Matchers {
       builder.build(Ctx("goodbye", "world")) should equal("GOODBYE cruel WORLD goodbye")
     }
 
+    it("helpers can take a nested helper") {
+      case class Ctx(worldKey: String)
+      val template = "goodbye {{cruel ( world ) }}"
+      val helpers = Map (
+        "cruel" -> Helper[Any] {
+          (context, options) =>
+            "cruel %s".format(options.argument(0).get.toString.toUpperCase)
+        },
+
+        "world" -> Helper[Any] {
+          (context, options) =>
+            options.lookup("worldKey").render + "!"
+        }
+      )
+      val builder = Handlebars.createBuilder(template).withHelpers(helpers)
+      builder.build(Ctx("world")) should equal("goodbye cruel WORLD!")
+    }
+
+    it("helpers can take a nested helper within nested helper") {
+      case class Ctx(worldKey: String)
+      val template = "goodbye {{cruel ( cruel (world) ) }}"
+      val helpers = Map (
+        "cruel" -> Helper[Any] {
+          (context, options) =>
+            "cruel %s".format(options.argument(0).get.toString.toUpperCase)
+        },
+
+        "world" -> Helper[Any] {
+          (context, options) =>
+            options.lookup("worldKey").render + "!"
+        }
+      )
+      val builder = Handlebars.createBuilder(template).withHelpers(helpers)
+      builder.build(Ctx("world")) should equal("goodbye cruel CRUEL WORLD!")
+    }
+
     it("helpers can take an optional hash") {
       val template = "{{goodbye cruel=\"CRUEL\" world=\"WORLD\" times=12}}"
       val helpers = Map (


### PR DESCRIPTION
Fixes #53

Parameters for helpers are parsed as mustache expressions if enclosed in parentheses.