### PR TITLE
'% test' slf4j-simple

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -24,7 +24,7 @@ val commonSettings = Seq(
 
   libraryDependencies ++= Seq(
     "org.slf4j" % "slf4j-api" % "1.6.4",
-    "org.slf4j" % "slf4j-simple" % "1.6.4",
+    "org.slf4j" % "slf4j-simple" % "1.6.4" % "test",
     "org.scalatest" %% "scalatest" % "2.2.4" % "test"
   ) ++ scala211Dependencies(scalaVersion.value),
 


### PR DESCRIPTION
I'm still seeing slf4j-simple pulled in (https://github.com/mwunsch/handlebars.scala/issues/48). I think this should fix it.