### PR TITLE
add implicit codec to handle java.nio.charset.MalformedInputException

### DIFF
--- a/src/main/scala/com/gilt/handlebars/scala/parser/ProgramHelper.scala
+++ b/src/main/scala/com/gilt/handlebars/scala/parser/ProgramHelper.scala
@@ -1,8 +1,6 @@
 package com.gilt.handlebars.scala.parser
 
 import java.io.File
-import java.nio.charset.CodingErrorAction
-
 import scala.io.{Codec, Source}
 
 class TemplateNotFoundException(message: String) extends RuntimeException(message)
@@ -21,12 +19,9 @@ ${next}
     }
   }
 
-  def programFromFile(file: File): Program = {
+  def programFromFile(file: File)(implicit codec : Codec): Program = {
     if (file.exists()) {
-      implicit val codec = Codec("UTF-8")
-      codec.onMalformedInput(CodingErrorAction.REPLACE)
-      codec.onUnmappableCharacter(CodingErrorAction.REPLACE)
-      val parseResult = HandlebarsGrammar(Source.fromFile(file).mkString)
+      val parseResult = HandlebarsGrammar(Source.fromFile(file)(codec).mkString)
       parseResult.getOrElse(sys.error("Could not parse template:\n\n%s".format(parseResult.toString)))
     } else {
       throw new TemplateNotFoundException("Could not load template: %s".format(file.getAbsolutePath))

--- a/src/main/scala/com/gilt/handlebars/scala/parser/ProgramHelper.scala
+++ b/src/main/scala/com/gilt/handlebars/scala/parser/ProgramHelper.scala
@@ -1,7 +1,9 @@
 package com.gilt.handlebars.scala.parser
 
 import java.io.File
-import scala.io.Source
+import java.nio.charset.CodingErrorAction
+
+import scala.io.{Codec, Source}
 
 class TemplateNotFoundException(message: String) extends RuntimeException(message)
 
@@ -21,6 +23,9 @@ ${next}
 
   def programFromFile(file: File): Program = {
     if (file.exists()) {
+      implicit val codec = Codec("UTF-8")
+      codec.onMalformedInput(CodingErrorAction.REPLACE)
+      codec.onUnmappableCharacter(CodingErrorAction.REPLACE)
       val parseResult = HandlebarsGrammar(Source.fromFile(file).mkString)
       parseResult.getOrElse(sys.error("Could not parse template:\n\n%s".format(parseResult.toString)))
     } else {

--- a/src/main/scala/com/gilt/handlebars/scala/partial/PartialHelper.scala
+++ b/src/main/scala/com/gilt/handlebars/scala/partial/PartialHelper.scala
@@ -1,12 +1,13 @@
 package com.gilt.handlebars.scala.partial
 
 import java.io.File
+import java.nio.charset.CodingErrorAction
 
 import com.gilt.handlebars.scala.binding.BindingFactory
 import com.gilt.handlebars.scala.parser._
 import com.gilt.handlebars.scala.{Handlebars, HandlebarsImpl}
 
-import scala.io.Source
+import scala.io.{Codec, Source}
 
 /**
  * @author chicks
@@ -48,6 +49,9 @@ object PartialHelper extends ProgramHelper {
    */
   def findAllPartials(file: File, touchedFiles: Seq[String] = Seq()): Map[String, File] = {
     if (file.exists() && !touchedFiles.contains(file.getAbsolutePath)) {
+      implicit val codec = Codec("UTF-8")
+      codec.onMalformedInput(CodingErrorAction.REPLACE)
+      codec.onUnmappableCharacter(CodingErrorAction.REPLACE)
       val contents = Source.fromFile(file).mkString
       val parseResult = HandlebarsGrammar(contents)
       parseResult.map { program =>


### PR DESCRIPTION
```
"scala.io.BufferedSource.mkString(BufferedSource.scala:96)",
    "com.gilt.handlebars.scala.partial.PartialHelper$.findAllPartials(PartialHelper.scala:51)",
    "com.gilt.handlebars.scala.partial.PartialHelper$.getTemplates(PartialHelper.scala:67)",
    "com.gilt.handlebars.scala.DefaultHandlebarsBuilder$.apply(HandlebarsBuilder.scala:40)",
    "com.gilt.handlebars.scala.Handlebars$.createBuilder(Handlebars.scala:48)",
  ```

see http://stackoverflow.com/questions/13625024/how-to-read-a-text-file-with-mixed-encodings-in-scala-or-java