### PR TITLE
SBT dependency change to play-json 2.5.4 to avoid NoSuchMethodError JsLookup

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -110,7 +110,7 @@ lazy val `play-json` = (project in file("./addons/play-json/")).
   settings(commonSettings: _*).
   settings(
     name := "handlebars-scala-play-json",
-    libraryDependencies += "com.typesafe.play" %% "play-json" % "2.4.2").
+    libraryDependencies += "com.typesafe.play" %% "play-json" % "2.5.4").
   dependsOn(core)
 
 lazy val `all` = (project in file("./addons/all")).

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "2.1.1"
+version in ThisBuild := "2.1.2-SNAPSHOT"


### PR DESCRIPTION
Awesome library, thank you!
Making use of it successfully in my Play 2.5 application
Using the -SNAPSHOT extension until pull request is merged.

This is the fix for the mysterious runtime exception:
java.lang.NoSuchMethodError: play.api.libs.json.JsLookup

Caused by: java.lang.NoSuchMethodError: play.api.libs.json.JsLookup$.$bslash$extension(Lplay/api/libs/json/JsLookupResult;Ljava/lang/String;)Lplay/api/libs/json/JsLookupResult;
    at com.gilt.handlebars.scala.binding.playjson.PlayJsonBinding.traverse(PlayJsonBinding.scala:44)
    at com.gilt.handlebars.scala.context.Context$class.lookup(Context.scala:73)
    at com.gilt.handlebars.scala.context.RootContext.lookup(Context.scala:14)
    at com.gilt.handlebars.scala.context.Context$class.lookup(Context.scala:34)
    at com.gilt.handlebars.scala.context.RootContext.lookup(Context.scala:14)
    at com.gilt.handlebars.scala.visitor.DefaultVisitor$$anonfun$2.apply(DefaultVisitor.scala:78)
    at com.gilt.handlebars.scala.visitor.DefaultVisitor$$anonfun$2.apply(DefaultVisitor.scala:78)
    at scala.Option.orElse(Option.scala:289)
    at com.gilt.handlebars.scala.visitor.DefaultVisitor.visit(DefaultVisitor.scala:76)
    at com.gilt.handlebars.scala.visitor.DefaultVisitor.visit(DefaultVisitor.scala:45)
