### PR TITLE
Strict rendering. Fixes #70

### DIFF
--- a/src/main/scala/com/gilt/handlebars/scala/CachingHandlebars.scala
+++ b/src/main/scala/com/gilt/handlebars/scala/CachingHandlebars.scala
@@ -53,6 +53,12 @@ case class CachingHandlebarsImpl[T](
    helpers: Map[String, Helper[T]],
    sourceFile: Option[String])(implicit f: BindingFactory[T]) extends CachingHandlebars[T] {
 
+  override def renderStrict(
+     binding: Binding[T],
+     data: Map[String, Binding[T]],
+     providedPartials: Map[String, Handlebars[T]],
+     providedHelpers: Map[String, Helper[T]])(implicit c: BindingFactory[T]): Either[List[String], String] = Right("") // Call to HandlebarsVisitor
+
   // TODO: Warn if we getOrElse is called. Didn't know how to re-load files.
   // TODO: Use handlebars builder to construct the new instance?
   def reload = sourceFile.map(file => CachingHandlebars.apply(new File(file))).getOrElse(this)

--- a/src/main/scala/com/gilt/handlebars/scala/logging/AccumulatingLoggable.scala
+++ b/src/main/scala/com/gilt/handlebars/scala/logging/AccumulatingLoggable.scala
@@ -1,0 +1,20 @@
+package com.gilt.handlebars.scala.logging
+
+import scala.collection.mutable
+
+/**
+  * Created by olivierdeckers on 25/11/2016.
+  */
+trait AccumulatingLoggable extends Loggable {
+  protected val errors: Option[mutable.MutableList[String]]
+
+  override def warn(message: String, t: Any*): Unit = {
+    errors.map(e => e += message)
+    super.warn(message, t)
+  }
+
+  override def warn(message: String, t: Throwable): Unit = {
+    errors.map(e => e += message)
+    super.warn(message, t)
+  }
+}

--- a/src/main/scala/com/gilt/handlebars/scala/parser/HandlebarsGrammar.scala
+++ b/src/main/scala/com/gilt/handlebars/scala/parser/HandlebarsGrammar.scala
@@ -90,7 +90,7 @@ class HandlebarsGrammar(delimiters: (String, String)) extends JavaTokenParsers {
   }
 
   def hashSegment = (ID ~ EQUALS ~ param) ^^ {
-    case (i ~ _ ~ p) => Pair(i, p)
+    case (i ~ _ ~ p) => (i, p)
   }
 
   def partialName = (path | STRING | INTEGER) ^^ { PartialName(_) }
@@ -115,7 +115,7 @@ class HandlebarsGrammar(delimiters: (String, String)) extends JavaTokenParsers {
 
   def comment = mustachify("!" ~> CONTENT) ^^ { Comment(_) }
 
-  def blockify(prefix: Parser[String]): Parser[Pair[Mustache, Option[Program]]] = {
+  def blockify(prefix: Parser[String]): Parser[(Mustache, Option[Program])] = {
     blockstache(prefix) ~ opt(program) ~ mustachify("/" ~> pad(path)) >> {
       case (mustache ~ _ ~ close) if close != mustache.path => failure(mustache.path.string + " doesn't match " +
 close.string)

--- a/src/test/scala/com/gilt/handlebars/scala/HandlebarsSpec.scala
+++ b/src/test/scala/com/gilt/handlebars/scala/HandlebarsSpec.scala
@@ -7,4 +7,25 @@ class HandlebarsSpec extends FunSpec with Matchers {
   describe("Issue #36 - Handlebars creation with empty string") {
     val hbs = Handlebars("")
   }
+
+  describe("Handlebars strict rendering") {
+    it("should return errors when path missing") {
+      val hbs = Handlebars("Hello {{name}}")
+      val result = hbs.renderStrict(Map("nme" -> "world"))
+      result match {
+        case Right(_) => fail
+        case Left(errors) =>
+          errors.head should include("Could not find path or helper: Identifier(List(name))")
+      }
+    }
+
+    it("should render when there are no errors") {
+      val hbs = Handlebars("Hello {{name}}")
+      val result = hbs.renderStrict(Map("name" -> "world"))
+      result match {
+        case Right(s) => s shouldEqual "Hello world"
+        case Left(errors) => fail
+      }
+    }
+  }
 }


### PR DESCRIPTION
When rendering strictly, the render method returns a list of errors instead of a template if it encountered any errors. fixes #70 