### PR TITLE
Build updates to Sbt 1.1.2, Scala 2.12.4, and Play-json 2.6.9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .settings/
+.bsp/
 .classpath
 .project
 .cache

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -6,4 +6,7 @@ How to deploy:
 - `sbt all/updateVersion` (task will update the versions in `./README.md` and `addons/play-json/README.md`)
 - `sbt all/publish`
   - Or, `sbt core/publishSigned play-json/publishSigned`
+  - Or, `sbt all/publishLocal`
 - Commit, tag, push, etc.
+
+

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This project began as an attempt to learn Scala and to experiment with Scala's [
 
 If you're using SBT you can add this line to your build.sbt file.
 
-    libraryDependencies += "com.gilt" %% "handlebars-scala" % "2.1.1"
+    libraryDependencies += "com.gilt" %% "handlebars-scala" % "2.2.0-SNAPSHOT"
 
 ## Usage
 
@@ -171,7 +171,7 @@ If you wish for more type-safety, Handlebars-scala comes with integration for pl
 
 To use:
 
-    libraryDependencies += "com.gilt" %% "handlebars-scala-play-json" % "2.1.1"
+    libraryDependencies += "com.gilt" %% "handlebars-scala-play-json" % "2.2.0-SNAPSHOT"
 
 [Example / usage](addons/play-json/README.md)
 

--- a/addons/play-json/README.md
+++ b/addons/play-json/README.md
@@ -6,7 +6,7 @@ Play-JSON data bindings for `handlebars.scala`. Requires `play-json` `2.4.x`.
 # Installation:
 
 ```scala
-libraryDependencies += "com.gilt" %% "handlebars-scala-play-json" % "2.1.1"
+libraryDependencies += "com.gilt" %% "handlebars-scala-play-json" % "2.2.0-SNAPSHOT"
 ```
 
 # Example:

--- a/build.properties
+++ b/build.properties
@@ -1,1 +1,0 @@
-sbt.version=0.13.0

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ def scala211Dependencies(scalaVersion:String) = {
   CrossVersion.partialVersion(scalaVersion) match {
     case Some((2, scalaMajor)) if scalaMajor >= 11 =>
       Seq(
-        "org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.1")
+        "org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.7")
     case _ =>
       Seq()
   }
@@ -12,20 +12,21 @@ val updateVersion = taskKey[Unit]("Updates version in README")
 libraryDependencies ++= Seq(
   "org.slf4j" % "slf4j-api" % "1.6.4",
   "org.slf4j" % "slf4j-simple" % "1.6.4" % "test",
-  "org.scalatest" %% "scalatest" % "2.1.6" % "test"
+  "org.scalatest" %% "scalatest" % "3.0.5" % "test"
 ) ++ scala211Dependencies(scalaVersion.value)
 
 val commonSettings = Seq(
   organization := "com.gilt",
 
-  scalaVersion := "2.11.7",
+  // scalaVersion := "2.11.7",
+  scalaVersion := "2.12.4",
 
-  crossScalaVersions := Seq("2.11.7", "2.10.5"),
+  crossScalaVersions := Seq("2.12.4", "2.11.7", "2.10.5"),
 
   libraryDependencies ++= Seq(
     "org.slf4j" % "slf4j-api" % "1.6.4",
     "org.slf4j" % "slf4j-simple" % "1.6.4" % "test",
-    "org.scalatest" %% "scalatest" % "2.2.4" % "test"
+    "org.scalatest" %% "scalatest" % "3.0.5" % "test"
   ) ++ scala211Dependencies(scalaVersion.value),
 
   updateVersion := {
@@ -51,6 +52,7 @@ val commonSettings = Seq(
 
   publishMavenStyle := true,
 
+  /* Disabling Sontatype publishing in my fork
   publishTo <<= version { (v: String) =>
     val nexus = "https://oss.sonatype.org/"
     if (v.trim.endsWith("SNAPSHOT"))
@@ -58,6 +60,7 @@ val commonSettings = Seq(
     else
       Some("releases"  at nexus + "/service/local/staging/deploy/maven2")
   },
+  */
 
   // For publishing / testing locally
   //publishTo := Some(Resolver.file("m2",  new File(Path.userHome.absolutePath+"/.m2/repository")))

--- a/build.sbt
+++ b/build.sbt
@@ -111,7 +111,7 @@ lazy val `play-json` = (project in file("./addons/play-json/")).
   settings(commonSettings: _*).
   settings(
     name := "handlebars-scala-play-json",
-    libraryDependencies += "com.typesafe.play" %% "play-json" % "2.5.4").
+    libraryDependencies += "com.typesafe.play" %% "play-json" % "2.6.9").
   dependsOn(core)
 
 lazy val `all` = (project in file("./addons/all")).

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ def scala211Dependencies(scalaVersion:String) = {
   CrossVersion.partialVersion(scalaVersion) match {
     case Some((2, scalaMajor)) if scalaMajor >= 11 =>
       Seq(
-        "org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.7")
+        "org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.1")
     case _ =>
       Seq()
   }
@@ -12,21 +12,20 @@ val updateVersion = taskKey[Unit]("Updates version in README")
 libraryDependencies ++= Seq(
   "org.slf4j" % "slf4j-api" % "1.6.4",
   "org.slf4j" % "slf4j-simple" % "1.6.4" % "test",
-  "org.scalatest" %% "scalatest" % "3.0.5" % "test"
+  "org.scalatest" %% "scalatest" % "2.1.6" % "test"
 ) ++ scala211Dependencies(scalaVersion.value)
 
 val commonSettings = Seq(
   organization := "com.gilt",
 
-  // scalaVersion := "2.11.7",
-  scalaVersion := "2.12.4",
+  scalaVersion := "2.11.7",
 
-  crossScalaVersions := Seq("2.12.4", "2.11.7", "2.10.5"),
+  crossScalaVersions := Seq("2.11.7", "2.10.5"),
 
   libraryDependencies ++= Seq(
     "org.slf4j" % "slf4j-api" % "1.6.4",
     "org.slf4j" % "slf4j-simple" % "1.6.4" % "test",
-    "org.scalatest" %% "scalatest" % "3.0.5" % "test"
+    "org.scalatest" %% "scalatest" % "2.2.4" % "test"
   ) ++ scala211Dependencies(scalaVersion.value),
 
   updateVersion := {
@@ -51,19 +50,17 @@ val commonSettings = Seq(
   ),
 
   publishMavenStyle := true,
-
-  /* Disabling Sontatype publishing in my fork
-  publishTo <<= version { (v: String) =>
+// 2020Mar28 SBT 2 Update, we're not publishing
+/*  publishTo <<= version { (v: String) =>
     val nexus = "https://oss.sonatype.org/"
     if (v.trim.endsWith("SNAPSHOT"))
       Some("snapshots" at nexus + "content/repositories/snapshots")
     else
       Some("releases"  at nexus + "/service/local/staging/deploy/maven2")
   },
-  */
-
+*/
   // For publishing / testing locally
-  publishTo := Some(Resolver.file("m2",  new File(Path.userHome.absolutePath+"/.m2/repository"))),
+  //publishTo := Some(Resolver.file("m2",  new File(Path.userHome.absolutePath+"/.m2/repository")))
 
   publishArtifact in Test := false,
 
@@ -113,7 +110,7 @@ lazy val `play-json` = (project in file("./addons/play-json/")).
   settings(commonSettings: _*).
   settings(
     name := "handlebars-scala-play-json",
-    libraryDependencies += "com.typesafe.play" %% "play-json" % "2.6.9").
+    libraryDependencies += "com.typesafe.play" %% "play-json" % "2.5.4").
   dependsOn(core)
 
 lazy val `all` = (project in file("./addons/all")).

--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,6 @@
+// Changelog
+// 2.2.0 - Update to sbt 1.6.2, play-json 2.8.2
+
 def scala211Dependencies(scalaVersion:String) = {
   CrossVersion.partialVersion(scalaVersion) match {
     case Some((2, scalaMajor)) if scalaMajor >= 11 =>
@@ -21,7 +24,7 @@ val commonSettings = Seq(
   scalaVersion := "2.12.11",
   // scalaVersion := "2.11.7",
 
-  crossScalaVersions := Seq("2.12.11", "2.11.7", "2.10.5"),
+  crossScalaVersions := Seq("2.12.17", "2.11.7", "2.10.5"),
 
   libraryDependencies ++= Seq(
     "org.slf4j" % "slf4j-api" % "1.6.4",
@@ -63,7 +66,7 @@ val commonSettings = Seq(
   // For publishing / testing locally
   //publishTo := Some(Resolver.file("m2",  new File(Path.userHome.absolutePath+"/.m2/repository")))
 
-  publishArtifact in Test := false,
+  Test / publishArtifact := false,
 
   pomIncludeRepository := { _ => false },
 
@@ -111,7 +114,7 @@ lazy val `play-json` = (project in file("./addons/play-json/")).
   settings(commonSettings: _*).
   settings(
     name := "handlebars-scala-play-json",
-    libraryDependencies += "com.typesafe.play" %% "play-json" % "2.6.9").
+    libraryDependencies += "com.typesafe.play" %% "play-json" % "2.8.2").
   dependsOn(core)
 
 lazy val `all` = (project in file("./addons/all")).

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ def scala211Dependencies(scalaVersion:String) = {
   CrossVersion.partialVersion(scalaVersion) match {
     case Some((2, scalaMajor)) if scalaMajor >= 11 =>
       Seq(
-        "org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.1")
+        "org.scala-lang.modules" %% "scala-parser-combinators" % "1.1.2")
     case _ =>
       Seq()
   }
@@ -12,20 +12,21 @@ val updateVersion = taskKey[Unit]("Updates version in README")
 libraryDependencies ++= Seq(
   "org.slf4j" % "slf4j-api" % "1.6.4",
   "org.slf4j" % "slf4j-simple" % "1.6.4" % "test",
-  "org.scalatest" %% "scalatest" % "2.1.6" % "test"
+  "org.scalatest" %% "scalatest" % "3.1.1" % "test"
 ) ++ scala211Dependencies(scalaVersion.value)
 
 val commonSettings = Seq(
   organization := "com.gilt",
 
-  scalaVersion := "2.11.7",
+  scalaVersion := "2.12.11",
+  // scalaVersion := "2.11.7",
 
-  crossScalaVersions := Seq("2.11.7", "2.10.5"),
+  crossScalaVersions := Seq("2.12.11", "2.11.7", "2.10.5"),
 
   libraryDependencies ++= Seq(
     "org.slf4j" % "slf4j-api" % "1.6.4",
     "org.slf4j" % "slf4j-simple" % "1.6.4" % "test",
-    "org.scalatest" %% "scalatest" % "2.2.4" % "test"
+    "org.scalatest" %% "scalatest" % "3.1.1" % "test"
   ) ++ scala211Dependencies(scalaVersion.value),
 
   updateVersion := {
@@ -40,8 +41,8 @@ val commonSettings = Seq(
   },
 
   resolvers ++= Seq(
-    "Sonatype.org Snapshots" at "http://oss.sonatype.org/content/repositories/snapshots",
-    "Sonatype.org Releases" at "http://oss.sonatype.org/service/local/staging/deploy/maven2"
+    "Sonatype.org Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots",
+    "Sonatype.org Releases" at "https://oss.sonatype.org/service/local/staging/deploy/maven2"
   ),
 
   scalacOptions ++= Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -113,7 +113,7 @@ lazy val `play-json` = (project in file("./addons/play-json/")).
   settings(commonSettings: _*).
   settings(
     name := "handlebars-scala-play-json",
-    libraryDependencies += "com.typesafe.play" %% "play-json" % "2.5.4").
+    libraryDependencies += "com.typesafe.play" %% "play-json" % "2.6.9").
   dependsOn(core)
 
 lazy val `all` = (project in file("./addons/all")).

--- a/build.sbt
+++ b/build.sbt
@@ -51,16 +51,16 @@ val commonSettings = Seq(
 
   publishMavenStyle := true,
 
-  publishTo <<= version { (v: String) =>
-    val nexus = "https://oss.sonatype.org/"
-    if (v.trim.endsWith("SNAPSHOT"))
-      Some("snapshots" at nexus + "content/repositories/snapshots")
-    else
-      Some("releases"  at nexus + "/service/local/staging/deploy/maven2")
-  },
+//  publishTo <<= version { (v: String) =>
+//    val nexus = "https://oss.sonatype.org/"
+//    if (v.trim.endsWith("SNAPSHOT"))
+//      Some("snapshots" at nexus + "content/repositories/snapshots")
+//    else
+//      Some("releases"  at nexus + "/service/local/staging/deploy/maven2")
+//  },
 
   // For publishing / testing locally
-  //publishTo := Some(Resolver.file("m2",  new File(Path.userHome.absolutePath+"/.m2/repository")))
+  publishTo := Some(Resolver.file("m2",  new File(Path.userHome.absolutePath+"/.m2/repository"))),
 
   publishArtifact in Test := false,
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.1.2

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.1.1

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.8
+sbt.version=1.6.2

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,5 +1,1 @@
-<<<<<<< HEAD
-sbt.version=1.1.1
-=======
-sbt.version=1.1.2
->>>>>>> 4c2acf47694b1ecefc5f2bffefb625f1471841a1
+sbt.version=1.3.8

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.1")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.1")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.0")

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "2.1.2-SNAPSHOT"
+ThisBuild / version := "2.2.0-SNAPSHOT"


### PR DESCRIPTION
Thanks for the great library! I continue to use it in my modern Play Framework applications.

This PR updates the build to use Sbt 1.1.2, Scala 2.12.4, play-json 2.6.9, The latest as of 2018Apr23